### PR TITLE
resized admin dashboard to accommodate computer screen with 100% width

### DIFF
--- a/src/styles/AdminDashboard.css
+++ b/src/styles/AdminDashboard.css
@@ -27,9 +27,14 @@
   justify-items: center;
 }
 
+.admin-dashboard-main {
+  transform: scale(.82) translateX(80px) translateY(-180px);
+}
+
 .admin-classes-view > .admin-dashboard-body > .admin-dashboard-main {
-  transform: scale(0.82) translateX(45px) translateY(-180px);
+  transform: scale(0.72) translateX(80px) translateY(-220px);
   border-radius: 5%;
+  box-shadow: rgba(0, 0, 0, 0.568) 0px 5px 100px;
 }
 
 .admin-classes-view > .admin-dashboard-body > .admin-dashboard-main > div {

--- a/src/styles/InventoryManagement.css
+++ b/src/styles/InventoryManagement.css
@@ -2,4 +2,6 @@
   border-radius: 20px;
   overflow: hidden;
   margin-bottom: 20px;
+  transform: scale(.95) translateY(160px);
+  box-shadow: rgba(0, 0, 0, 0.568) 0px 5px 100px;
 }


### PR DESCRIPTION
Fixed sizing issue on the admin dashboard so the deployed website will appear correctly

**Updated**:
<img width="1920" height="1020" alt="Screenshot 2025-08-15 172457" src="https://github.com/user-attachments/assets/a7b9b780-22c8-4aaf-afc1-073f2fef3e2f" />
<img width="1920" height="1020" alt="Screenshot 2025-08-15 172443" src="https://github.com/user-attachments/assets/53a21ecf-f4bf-4a76-8220-aef76a1d5cbe" />
<img width="1920" height="1020" alt="Screenshot 2025-08-15 172423" src="https://github.com/user-attachments/assets/6ea0fc1a-dc7a-4a63-89b6-a1d12ac4f35a" />


_current_:

<img width="1920" height="1020" alt="Screenshot 2025-08-15 172854" src="https://github.com/user-attachments/assets/a16e0170-cecf-4447-ad4c-adc918a46916" />
<img width="1920" height="1020" alt="Screenshot 2025-08-15 172752" src="https://github.com/user-attachments/assets/bcf90ee1-03c3-4e72-94c0-eaffea772058" />
<img width="1920" height="1020" alt="Screenshot 2025-08-15 172744" src="https://github.com/user-attachments/assets/36b10bf2-2e6e-482e-a8ad-e4ae39c630c4" />

